### PR TITLE
getLink method for Channel

### DIFF
--- a/framework/core/Channel.js
+++ b/framework/core/Channel.js
@@ -385,6 +385,14 @@ var Channel = (new function KChannel() {
 	};
 	
 	/*
+		Create a link to join a channel
+	*/
+	this.getLink = function getLink() {
+		var channelName = Channel.getName();
+		return "°>" + channelName + "|/go " + channelName + "|/go +" + channelName + "<°";
+	}
+	
+	/*
 		@docs	http://www.mychannel-apps.de/documentation/Channel_toString
 	*/
 	this.toString = function toString() {


### PR DESCRIPTION
It is possible to create a link to a channel via channel.getLink().
Left click open the channel in the same window, right click opens in a new window.
